### PR TITLE
Handle routes with trailing spaces

### DIFF
--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -90,7 +90,7 @@ describe LuckyRouter do
     router = LuckyRouter::Matcher(Symbol).new
     router.add("get", "/users/:id", :show)
 
-    describe "is defined with a trailing slash" do
+    context "is defined with a trailing slash" do
       router.add("get", "/users/", :index)
 
       it "should treat it as a index route when called without a trailing slash" do
@@ -102,7 +102,7 @@ describe LuckyRouter do
       end
     end
 
-    describe "is defined without a trailing slash" do
+    context "is defined without a trailing slash" do
       router.add("get", "/users", :index)
 
       it "should treat it as a index route when called without a trailing slash" do

--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -86,30 +86,30 @@ describe LuckyRouter do
     router.match!("get", "/something").payload.should eq :category_index
   end
 
-  describe "route with trailling slash" do
+  describe "route with trailing slash" do
     router = LuckyRouter::Matcher(Symbol).new
     router.add("get", "/users/:id", :show)
 
-    describe "is defined with a trailling slash" do
+    describe "is defined with a trailing slash" do
       router.add("get", "/users/", :index)
 
-      it "should treat it as a index route when called without a trailling slash" do
+      it "should treat it as a index route when called without a trailing slash" do
         router.match!("get", "/users").payload.should eq :index
       end
   
-      it "should treat it as a index route when called with a trailling slash" do
+      it "should treat it as a index route when called with a trailing slash" do
         router.match!("get", "/users/").payload.should eq :index
       end
     end
 
-    describe "is defined without a trailling slash" do
+    describe "is defined without a trailing slash" do
       router.add("get", "/users", :index)
 
-      it "should treat it as a index route when called without a trailling slash" do
+      it "should treat it as a index route when called without a trailing slash" do
         router.match!("get", "/users").payload.should eq :index
       end
 
-      it "should treat it as a index route when called with a trailling slash" do
+      it "should treat it as a index route when called with a trailing slash" do
         router.match!("get", "/users/").payload.should eq :index
       end
     end

--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -85,4 +85,33 @@ describe LuckyRouter do
     router.match!("get", "/users").payload.should eq :index
     router.match!("get", "/something").payload.should eq :category_index
   end
+
+  describe "route with trailling slash" do
+    router = LuckyRouter::Matcher(Symbol).new
+    router.add("get", "/users/:id", :show)
+
+    describe "is defined with a trailling slash" do
+      router.add("get", "/users/", :index)
+
+      it "should treat it as a index route when called without a trailling slash" do
+        router.match!("get", "/users").payload.should eq :index
+      end
+  
+      it "should treat it as a index route when called with a trailling slash" do
+        router.match!("get", "/users/").payload.should eq :index
+      end
+    end
+
+    describe "is defined without a trailling slash" do
+      router.add("get", "/users", :index)
+
+      it "should treat it as a index route when called without a trailling slash" do
+        router.match!("get", "/users").payload.should eq :index
+      end
+
+      it "should treat it as a index route when called with a trailling slash" do
+        router.match!("get", "/users/").payload.should eq :index
+      end
+    end
+  end
 end

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -5,15 +5,14 @@ class LuckyRouter::Matcher(T)
   @routes = Hash(HttpMethod, Hash(RoutePartsSize, Fragment(T))).new
 
   def add(method : String, path : String, payload : T)
-    parts = path.split("/")
-
+    parts = extract_parts(path)
     routes[method] ||= Hash(RoutePartsSize, Fragment(T)).new
     routes[method][parts.size] ||= Fragment(T).new
     routes[method][parts.size].process_parts(parts, payload)
   end
 
   def match(method : String, path_to_match : String) : Match(T)?
-    parts_to_match = path_to_match.split("/")
+    parts_to_match = extract_parts(path_to_match)
     return if routes[method]?.try(&.[parts_to_match.size]?).nil?
     match = routes[method][parts_to_match.size].find(parts_to_match)
 
@@ -24,5 +23,11 @@ class LuckyRouter::Matcher(T)
 
   def match!(method : String, path_to_match : String) : Match(T)
     match(method, path_to_match) || raise "No matching route found for: #{path_to_match}"
+  end
+
+  private def extract_parts(path)
+    parts = path.split("/") 
+    parts.pop if parts.last.blank?
+    parts
   end
 end


### PR DESCRIPTION
Allows router to treat routes with trailing slashes the same as those without

`/management/users/` will be routed to `/management/users`

See https://github.com/luckyframework/lucky/issues/392