### PR TITLE
WIP: When a GET route is defined, also define HEAD

### DIFF
--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -44,6 +44,18 @@ describe LuckyRouter do
     router.match!("get", "/").payload.should eq :root
   end
 
+  it "allows head routes when a get route is defined" do
+    router = LuckyRouter::Matcher(Symbol).new
+    router.add("get", "/health", :health)
+    router.match!("head", "/health").payload.should eq :health
+  end
+
+  it "does not allow head routes when something else is defined" do
+    router = LuckyRouter::Matcher(Symbol).new
+    router.add("put", "/update", :update)
+    router.match("head", "/update").should be_nil
+  end
+
   it "does not blow up when there are no routes" do
     router = LuckyRouter::Matcher(Symbol).new
     router.match("post", "/users")

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -6,6 +6,11 @@ class LuckyRouter::Matcher(T)
 
   def add(method : String, path : String, payload : T)
     parts = extract_parts(path)
+    if method.downcase == "get"
+      routes["head"] ||= Hash(RoutePartsSize, Fragment(T)).new
+      routes["head"][parts.size] ||= Fragment(T).new
+      routes["head"][parts.size].process_parts(parts, payload)
+    end
     routes[method] ||= Hash(RoutePartsSize, Fragment(T)).new
     routes[method][parts.size] ||= Fragment(T).new
     routes[method][parts.size].process_parts(parts, payload)


### PR DESCRIPTION
This is in reference to https://github.com/luckyframework/lucky/issues/601

This PR will need to be added in conjunction with another on Lucky to actually support this.