### PR TITLE
Simplify and optimize routing

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.2.2
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
 
-crystal: 0.27
+crystal: 0.34
 
 license: MIT

--- a/spec/fragment_spec.cr
+++ b/spec/fragment_spec.cr
@@ -4,7 +4,7 @@ describe LuckyRouter::Fragment do
   it "adds parts successfully" do
     fragment = build_fragment
 
-    fragment.process_parts(["users", ":id"], :show)
+    fragment.process_parts(["users", ":id"], :show, "get")
 
     users_fragment = fragment.static_parts["users"]
     users_fragment.dynamic_part.should_not be_nil
@@ -13,8 +13,8 @@ describe LuckyRouter::Fragment do
   it "static parts after dynamic parts do not overwrite each other" do
     fragment = build_fragment
 
-    fragment.process_parts(["users", ":id", "edit"], :edit)
-    fragment.process_parts(["users", ":id", "new"], :new)
+    fragment.process_parts(["users", ":id", "edit"], :edit, "get")
+    fragment.process_parts(["users", ":id", "new"], :new, "get")
 
     users_fragment = fragment.static_parts["users"]
     id_fragment = users_fragment.dynamic_part.not_nil!.fragment

--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -16,21 +16,26 @@ router.add("put", "/users/:id", :update)
 router.add("get", "/users/:id/edit", :edit)
 router.add("get", "/users/:id/new", :new)
 
-time = Time.utc
-
+elapsed_times = [] of Time::Span
 1000.times do
-  router.match!("post", "/users")
-  router.match!("get", "/users/1")
-  router.match!("delete", "/users/1")
-  router.match!("put", "/users/1")
-  router.match!("get", "/users/1/edit")
-  router.match!("get", "/users/1/new")
+  time = Time.utc
+
+  1000.times do
+    router.match!("post", "/users")
+    router.match!("get", "/users/1")
+    router.match!("delete", "/users/1")
+    router.match!("put", "/users/1")
+    router.match!("get", "/users/1/edit")
+    router.match!("get", "/users/1/new")
+  end
+
+  elapsed = Time.utc - time
+  elapsed_times << elapsed
 end
 
-elapsed = Time.utc - time
-elapsed_text = elapsed_text(elapsed)
-
-puts elapsed_text
+sum = elapsed_times.sum
+average = sum / elapsed_times.size
+puts "Average time: " + elapsed_text(average)
 
 private def elapsed_text(elapsed)
   minutes = elapsed.total_minutes

--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -16,7 +16,7 @@ router.add("put", "/users/:id", :update)
 router.add("get", "/users/:id/edit", :edit)
 router.add("get", "/users/:id/new", :new)
 
-time = Time.now
+time = Time.utc
 
 1000.times do
   router.match!("post", "/users")
@@ -27,7 +27,7 @@ time = Time.now
   router.match!("get", "/users/1/new")
 end
 
-elapsed = Time.now - time
+elapsed = Time.utc - time
 elapsed_text = elapsed_text(elapsed)
 
 puts elapsed_text

--- a/src/lucky_router/fragment.cr
+++ b/src/lucky_router/fragment.cr
@@ -53,16 +53,30 @@ class LuckyRouter::Fragment(T)
 
   alias StaticPartName = String
   # The payload is only set on the last fragment
-  property payload : T?
   property dynamic_part : DynamicFragment(T)?
   getter static_parts = Hash(StaticPartName, Fragment(T)).new
+  getter method_to_payload = {} of String => T
 
-  def process_parts(parts : Array(String), payload : T)
-    PartProcessor(T).new(self, parts: parts, payload: payload).run
-    self
+  def initialize(@dynamic : Bool = false)
   end
 
-  def find(parts : Array(String)) : Match(T) | NoMatch
-    MatchFinder(T).new(self, parts: parts).run
+  def dynamic?
+    @dynamic
+  end
+
+  def process_parts(parts : Array(String), payload : T, method : String)
+    PartProcessor(T).new(self, parts: parts, payload: payload, method: method).run
+  end
+
+  def find(parts : Array(String), method : String) : Match(T)?
+    MatchFinder(T).new(self, parts: parts, method: method).run
+  end
+
+  def dynamic_fragment : Fragment(T)?
+    dynamic_part.try(&.fragment)
+  end
+
+  def fragment_matching(part : StaticPartName) : Fragment(T)?
+    static_parts.fetch(part) { dynamic_fragment }
   end
 end

--- a/src/lucky_router/match_finder.cr
+++ b/src/lucky_router/match_finder.cr
@@ -1,5 +1,6 @@
 class LuckyRouter::MatchFinder(T)
-  private getter fragment, parts, params
+  private getter parts, method, params
+  private property fragment
 
   @fragment : Fragment(T)
   # The parts are the raw strings from each section of the path.
@@ -12,40 +13,30 @@ class LuckyRouter::MatchFinder(T)
   # it'll then create a new MatchFinder and pass ["1", "edit"], until the last
   # fragment which will have just ["edit"] as the `parts`
   @parts : Array(String)
+  @method : String
   @params : Hash(String, String)
 
-  def initialize(@fragment, @parts, @params = {} of String => String)
+  def initialize(@fragment, @parts, @method, @params = {} of String => String)
   end
 
-  # This uses the magic/pain of recursion to continue matching fragments
-  # until there is a match in the final fragment, otherwise it returns `NoMatch`
-  def run : Match(T) | NoMatch
-    add_to_params if has_param?
+  # It continues matching fragments
+  # until there is a match in the final fragment,
+  # otherwise it returns nil
+  def run : Match(T)?
+    until parts.empty?
+      match = fragment.fragment_matching(current_part)
+      return if match.nil?
 
-    if last_part? && has_match?
-      # If we're on the last part and have a match, return the payload and params :D
-      Match(T).new(matched_fragment.not_nil!.payload.not_nil!, params)
-    elsif static_fragment
-      # Always try to match a static part before a dynamic one
-      MatchFinder(T).new(static_fragment.not_nil!, next_parts, params).run
-    elsif dynamic_fragment
-      # If no static part matches, check if the part can by dynamic
-      MatchFinder(T).new(dynamic_fragment.not_nil!, next_parts, params).run
-    else
-      NoMatch.new
+      add_to_params if match.dynamic?
+      if last_part?
+        payload = match.method_to_payload[method]?
+        # If we're on the last part and have a match, return the payload and params :D
+        return Match(T).new(payload, params) if payload
+      end
+
+      self.fragment = match
+      parts.shift
     end
-  end
-
-  private def has_param?
-    dynamic_fragment && static_fragment.nil?
-  end
-
-  private def has_match?
-    static_fragment || dynamic_fragment
-  end
-
-  private def matched_fragment
-    static_fragment || dynamic_fragment
   end
 
   private def last_part?
@@ -56,20 +47,8 @@ class LuckyRouter::MatchFinder(T)
     parts.first
   end
 
-  private def next_parts
-    parts.skip(1)
-  end
-
   private def add_to_params
     key = fragment.dynamic_part.not_nil!.name
     params[key] = current_part
-  end
-
-  private def static_fragment
-    fragment.static_parts[current_part]?
-  end
-
-  private def dynamic_fragment
-    fragment.dynamic_part.try(&.fragment)
   end
 end

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -16,39 +16,10 @@
 # router.match("get", "/users").payload # :index
 # ```
 class LuckyRouter::Matcher(T)
-  getter routes
+  getter root = Fragment(T).new
   # aliases to help clarify what the @routes has is made of
   alias RoutePartsSize = Int32
   alias HttpMethod = String
-
-  # The matcher stores routes based on the HTTP method and the number of
-  # "parts" in the path
-  #
-  # Each section in between the path is a "part". We use the method and part size
-  # to both speed up the route lookup and makes it more reliable because the router
-  # always tries to find routes that are the right size.
-  #
-  # Each route key is a `Fragment(T)`. Where `T` is the type of the payload. See
-  # `Fragment` for details on how it works
-  #
-  # ## Example
-  #
-  # ```
-  # router = LuckyRouter::Matcher(Symbol).new
-  # router.add("get", "/users/:user_id", :index)
-  #
-  # # Will make @routes look like:
-
-  # {
-  #   "get" => {
-  #     2 => Fragment(T) # The fragment for this route
-  #   }
-  # }
-  # ```
-  #
-  # So if trying to match "/users/1/foo" it will not even try because the parts
-  # size does not match any of the known routes.
-  @routes = Hash(HttpMethod, Hash(RoutePartsSize, Fragment(T))).new
 
   def add(method : String, path : String, payload : T)
     all_path_parts = path.split("/")
@@ -79,12 +50,7 @@ class LuckyRouter::Matcher(T)
 
   def match(method : String, path_to_match : String) : Match(T)?
     parts_to_match = extract_parts(path_to_match)
-    return if routes[method]?.try(&.[parts_to_match.size]?).nil?
-    match = routes[method][parts_to_match.size].find(parts_to_match)
-
-    if match.is_a?(Match)
-      match
-    end
+    root.find(parts_to_match, method)
   end
 
   def match!(method : String, path_to_match : String) : Match(T)
@@ -98,8 +64,6 @@ class LuckyRouter::Matcher(T)
   end
 
   private def add_route(method : String, parts : Array(String), payload : T)
-    routes[method] ||= Hash(RoutePartsSize, Fragment(T)).new
-    routes[method][parts.size] ||= Fragment(T).new
-    routes[method][parts.size].process_parts(parts, payload)
+    root.process_parts(parts, payload, method)
   end
 end

--- a/src/lucky_router/no_match.cr
+++ b/src/lucky_router/no_match.cr
@@ -1,2 +1,0 @@
-class LuckyRouter::NoMatch
-end

--- a/src/lucky_router/part_processor.cr
+++ b/src/lucky_router/part_processor.cr
@@ -1,11 +1,12 @@
 class LuckyRouter::PartProcessor(T)
-  private getter fragment, payload, parts
+  private getter fragment, payload, parts, method
 
   @fragment : Fragment(T)
   @payload : T
   @parts : Array(String)
+  @method : String
 
-  def initialize(@fragment, @parts, @payload)
+  def initialize(@fragment, @parts, @payload, @method)
   end
 
   def run
@@ -37,9 +38,9 @@ class LuckyRouter::PartProcessor(T)
   private def add_dynamic_part
     fragment.dynamic_part ||= Fragment::DynamicFragment.new(
       name: current_part.gsub(":", ""),
-      fragment: Fragment(T).new
+      fragment: Fragment(T).new(dynamic: true)
     )
-    fragment.dynamic_part.not_nil!.fragment.process_parts(next_parts, payload)
+    fragment.dynamic_part.not_nil!.fragment.process_parts(next_parts, payload, method)
 
     if on_last_part?
       add_payload_to_dynamic_part
@@ -52,14 +53,14 @@ class LuckyRouter::PartProcessor(T)
 
   private def add_static_part
     fragment.static_parts[current_part] ||= Fragment(T).new
-    fragment.static_parts[current_part].process_parts(next_parts, payload)
+    fragment.static_parts[current_part].process_parts(next_parts, payload, method)
 
     if next_parts.empty?
-      fragment.static_parts[current_part].payload = payload
+      fragment.static_parts[current_part].method_to_payload[method] = payload
     end
   end
 
   private def add_payload_to_dynamic_part
-    fragment.dynamic_part.not_nil!.fragment.payload = payload
+    fragment.dynamic_part.not_nil!.fragment.method_to_payload[method] = payload
   end
 end


### PR DESCRIPTION
## Main Optimizations

- Check http method last instead of first (moved from Matcher to Fragment)
- Use a loop in MatchFinder rather than recursion
- Drop hash in Matcher for a single root Fragment

## Other Changes

- Update benchmark to find an average of multiple runs for more accurate times
- Refactoring around MatchFinder and Fragment to simplify logic

## Performance Improvement

With the updated benchmark in this PR, I found that master currently finishes the benchmark with an average of 10.9 milliseconds. Running the benchmark with this PR returns an average of 6.8 milliseconds

- Old: 10.9 ms
- New: 6.8 ms
- Difference: 4.1 ms
- **Improvement: 38%**