### PR TITLE
Remove recursion from MatchFinder

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.2.2
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
 
-crystal: 0.27
+crystal: 0.34
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.2.2
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
 
-crystal: 0.34
+crystal: 0.35
 
 license: MIT

--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -16,21 +16,26 @@ router.add("put", "/users/:id", :update)
 router.add("get", "/users/:id/edit", :edit)
 router.add("get", "/users/:id/new", :new)
 
-time = Time.now
-
+elapsed_times = [] of Time::Span
 1000.times do
-  router.match!("post", "/users")
-  router.match!("get", "/users/1")
-  router.match!("delete", "/users/1")
-  router.match!("put", "/users/1")
-  router.match!("get", "/users/1/edit")
-  router.match!("get", "/users/1/new")
+  time = Time.utc
+
+  1000.times do
+    router.match!("post", "/users")
+    router.match!("get", "/users/1")
+    router.match!("delete", "/users/1")
+    router.match!("put", "/users/1")
+    router.match!("get", "/users/1/edit")
+    router.match!("get", "/users/1/new")
+  end
+
+  elapsed = Time.utc - time
+  elapsed_times << elapsed
 end
 
-elapsed = Time.now - time
-elapsed_text = elapsed_text(elapsed)
-
-puts elapsed_text
+sum = elapsed_times.sum
+average = sum / elapsed_times.size
+puts "Average time: " + elapsed_text(average)
 
 private def elapsed_text(elapsed)
   minutes = elapsed.total_minutes

--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -20,16 +20,16 @@ elapsed_times = [] of Time::Span
 1000.times do
   time = Time.utc
 
-  1000.times do
-    router.match!("post", "/users")
-    router.match!("get", "/users/1")
-    router.match!("delete", "/users/1")
-    router.match!("put", "/users/1")
-    router.match!("get", "/users/1/edit")
-    router.match!("get", "/users/1/new")
+  elapsed = Time.measure do
+    1000.times do
+      router.match!("post", "/users")
+      router.match!("get", "/users/1")
+      router.match!("delete", "/users/1")
+      router.match!("put", "/users/1")
+      router.match!("get", "/users/1/edit")
+      router.match!("get", "/users/1/new")
+    end
   end
-
-  elapsed = Time.utc - time
   elapsed_times << elapsed
 end
 

--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -18,8 +18,6 @@ router.add("get", "/users/:id/new", :new)
 
 elapsed_times = [] of Time::Span
 1000.times do
-  time = Time.utc
-
   elapsed = Time.measure do
     1000.times do
       router.match!("post", "/users")

--- a/src/lucky_router/match_finder.cr
+++ b/src/lucky_router/match_finder.cr
@@ -21,7 +21,7 @@ class LuckyRouter::MatchFinder(T)
   # This looks for a matching fragment for the given parts
   # and returns NoMatch if one is not found
   def run : Match(T) | NoMatch
-    until parts.empty?
+    loop do
       match = matched_fragment
       return NoMatch.new if match.nil?
 
@@ -31,6 +31,7 @@ class LuckyRouter::MatchFinder(T)
       end
       self.fragment = match
       parts.shift
+      break if parts.empty?
     end
 
     NoMatch.new

--- a/src/lucky_router/match_finder.cr
+++ b/src/lucky_router/match_finder.cr
@@ -18,8 +18,8 @@ class LuckyRouter::MatchFinder(T)
   def initialize(@fragment, @parts, @params = {} of String => String)
   end
 
-  # This uses the magic/pain of recursion to continue matching fragments
-  # until there is a match in the final fragment, otherwise it returns `NoMatch`
+  # This looks for a matching fragment for the given parts
+  # and returns NoMatch if one is not found
   def run : Match(T) | NoMatch
     until parts.empty?
       match = matched_fragment

--- a/src/lucky_router/match_finder.cr
+++ b/src/lucky_router/match_finder.cr
@@ -1,5 +1,6 @@
 class LuckyRouter::MatchFinder(T)
-  private getter fragment, parts, params
+  private getter parts, params
+  private property fragment
 
   @fragment : Fragment(T)
   # The parts are the raw strings from each section of the path.
@@ -20,20 +21,19 @@ class LuckyRouter::MatchFinder(T)
   # This uses the magic/pain of recursion to continue matching fragments
   # until there is a match in the final fragment, otherwise it returns `NoMatch`
   def run : Match(T) | NoMatch
-    add_to_params if has_param?
+    until parts.empty?
+      match = matched_fragment
+      return NoMatch.new if match.nil?
 
-    if last_part? && has_match?
-      # If we're on the last part and have a match, return the payload and params :D
-      Match(T).new(matched_fragment.not_nil!.payload.not_nil!, params)
-    elsif static_fragment
-      # Always try to match a static part before a dynamic one
-      MatchFinder(T).new(static_fragment.not_nil!, next_parts, params).run
-    elsif dynamic_fragment
-      # If no static part matches, check if the part can by dynamic
-      MatchFinder(T).new(dynamic_fragment.not_nil!, next_parts, params).run
-    else
-      NoMatch.new
+      add_to_params if has_param?
+      if last_part? && has_match?
+        return Match(T).new(matched_fragment.not_nil!.payload.not_nil!, params)
+      end
+      self.fragment = match
+      parts.shift
     end
+
+    NoMatch.new
   end
 
   private def has_param?


### PR DESCRIPTION
## Summary

This replaces a somewhat complicated recursive method with an almost equally complicated loop. The advantage is that loops are faster than recursion. More refactoring can be done in the future to clean up the code.

The benchmark code changes take an average of running the code many, many times so that the measurements can be more accurate.

## Benchmark

- Before: 12.3 ms
- After: 10.4 ms
- Difference: 1.9 ms
- Improvement: 15%

## Side Note

I tried to remove the `NoMatch` class and replace it with simply returning nil.  It actually was slower than keeping the `NoMatch` class and I have no idea why!