### PR TITLE
Move request method matching to the bottom level instead of the top

### DIFF
--- a/spec/fragment_spec.cr
+++ b/spec/fragment_spec.cr
@@ -4,7 +4,7 @@ describe LuckyRouter::Fragment do
   it "adds parts successfully" do
     fragment = build_fragment
 
-    fragment.process_parts(["users", ":id"], :show)
+    fragment.process_parts(["users", ":id"], "get", :show)
 
     users_fragment = fragment.static_parts["users"]
     users_fragment.dynamic_part.should_not be_nil
@@ -13,8 +13,8 @@ describe LuckyRouter::Fragment do
   it "static parts after dynamic parts do not overwrite each other" do
     fragment = build_fragment
 
-    fragment.process_parts(["users", ":id", "edit"], :edit)
-    fragment.process_parts(["users", ":id", "new"], :new)
+    fragment.process_parts(["users", ":id", "edit"], "get", :edit)
+    fragment.process_parts(["users", ":id", "new"], "get", :new)
 
     users_fragment = fragment.static_parts["users"]
     id_fragment = users_fragment.dynamic_part.not_nil!.fragment

--- a/src/lucky_router/fragment.cr
+++ b/src/lucky_router/fragment.cr
@@ -52,17 +52,16 @@ class LuckyRouter::Fragment(T)
   end
 
   alias StaticPartName = String
-  # The payload is only set on the last fragment
-  property payload : T?
   property dynamic_part : DynamicFragment(T)?
   getter static_parts = Hash(StaticPartName, Fragment(T)).new
+  getter method_to_payload = Hash(String, T).new
 
-  def process_parts(parts : Array(String), payload : T)
-    PartProcessor(T).new(self, parts: parts, payload: payload).run
+  def process_parts(parts : Array(String), method : String, payload : T)
+    PartProcessor(T).new(self, parts: parts, method: method, payload: payload).run
     self
   end
 
-  def find(parts : Array(String)) : Match(T) | NoMatch
-    MatchFinder(T).new(self, parts: parts).run
+  def find(parts : Array(String), method : String) : Match(T) | NoMatch
+    MatchFinder(T).new(self, parts: parts, method: method).run
   end
 end

--- a/src/lucky_router/fragment.cr
+++ b/src/lucky_router/fragment.cr
@@ -54,6 +54,9 @@ class LuckyRouter::Fragment(T)
   alias StaticPartName = String
   property dynamic_part : DynamicFragment(T)?
   getter static_parts = Hash(StaticPartName, Fragment(T)).new
+  # Every path can have multiple request methods
+  # and since each fragment represents a request path
+  # the final step to finding the payload is to search for a matching request method
   getter method_to_payload = Hash(String, T).new
 
   def process_parts(parts : Array(String), method : String, payload : T)

--- a/src/lucky_router/match_finder.cr
+++ b/src/lucky_router/match_finder.cr
@@ -1,5 +1,5 @@
 class LuckyRouter::MatchFinder(T)
-  private getter parts, params
+  private getter parts, params, method
   private property fragment
 
   @fragment : Fragment(T)
@@ -13,9 +13,10 @@ class LuckyRouter::MatchFinder(T)
   # it'll then create a new MatchFinder and pass ["1", "edit"], until the last
   # fragment which will have just ["edit"] as the `parts`
   @parts : Array(String)
+  @method : String
   @params : Hash(String, String)
 
-  def initialize(@fragment, @parts, @params = {} of String => String)
+  def initialize(@fragment, @parts, @method, @params = {} of String => String)
   end
 
   # This looks for a matching fragment for the given parts
@@ -27,7 +28,8 @@ class LuckyRouter::MatchFinder(T)
 
       add_to_params if has_param?
       if last_part? && has_match?
-        return Match(T).new(matched_fragment.not_nil!.payload.not_nil!, params)
+        payload = matched_fragment.not_nil!.method_to_payload[method]?
+        return payload.nil? ? NoMatch.new : Match(T).new(payload, params)
       end
       self.fragment = match
       parts.shift

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -19,6 +19,7 @@ class LuckyRouter::Matcher(T)
   # aliases to help clarify what the @routes has is made of
   alias RoutePartsSize = Int32
   alias HttpMethod = String
+  # starting point from which all fragments are located
   getter root = Fragment(T).new
 
   def add(method : String, path : String, payload : T)

--- a/src/lucky_router/part_processor.cr
+++ b/src/lucky_router/part_processor.cr
@@ -1,11 +1,12 @@
 class LuckyRouter::PartProcessor(T)
-  private getter fragment, payload, parts
+  private getter fragment, payload, method, parts
 
   @fragment : Fragment(T)
   @payload : T
   @parts : Array(String)
+  @method : String
 
-  def initialize(@fragment, @parts, @payload)
+  def initialize(@fragment, @parts, @method, @payload)
   end
 
   def run
@@ -39,7 +40,7 @@ class LuckyRouter::PartProcessor(T)
       name: current_part.gsub(":", ""),
       fragment: Fragment(T).new
     )
-    fragment.dynamic_part.not_nil!.fragment.process_parts(next_parts, payload)
+    fragment.dynamic_part.not_nil!.fragment.process_parts(next_parts, method, payload)
 
     if on_last_part?
       add_payload_to_dynamic_part
@@ -52,14 +53,14 @@ class LuckyRouter::PartProcessor(T)
 
   private def add_static_part
     fragment.static_parts[current_part] ||= Fragment(T).new
-    fragment.static_parts[current_part].process_parts(next_parts, payload)
+    fragment.static_parts[current_part].process_parts(next_parts, method, payload)
 
     if next_parts.empty?
-      fragment.static_parts[current_part].payload = payload
+      fragment.static_parts[current_part].method_to_payload[method] = payload
     end
   end
 
   private def add_payload_to_dynamic_part
-    fragment.dynamic_part.not_nil!.fragment.payload = payload
+    fragment.dynamic_part.not_nil!.fragment.method_to_payload[method] = payload
   end
 end


### PR DESCRIPTION
## Summary

Fixes #27 

This change increases the speed of the routing library when a valid request is made.

Beyond just increasing the speed, this is another step towards a larger refactor of the internals. The big idea is to move the decision logic all into one place so that pieces can then be refactored to bring more clarity and conciseness. At this point, I do not believe that the library is any more or less clear but by moving this down into the Fragment class, we can refactor the `PartProcessor` and `MatchFinder` classes later on.

**NOTE**: this is definitely a breaking change for the internal API if that is a concern

## Benchmark (with `--release`)

- Before: 215 ms
- After: 204 ms
- Difference: 11 ms
- Improvement: 5%