### PR TITLE
Extract path parts into their own class

### DIFF
--- a/spec/fragment_spec.cr
+++ b/spec/fragment_spec.cr
@@ -6,7 +6,7 @@ describe LuckyRouter::Fragment do
 
     fragment.process_parts(build_path_parts("users", ":id"), "get", :show)
 
-    users_fragment = fragment.static_parts[LuckyRouter::PathPart.new("users")]
+    users_fragment = fragment.static_parts["users"]
     users_fragment.dynamic_part.should_not be_nil
   end
 
@@ -16,10 +16,10 @@ describe LuckyRouter::Fragment do
     fragment.process_parts(build_path_parts("users", ":id", "edit"), "get", :edit)
     fragment.process_parts(build_path_parts("users", ":id", "new"), "get", :new)
 
-    users_fragment = fragment.static_parts[LuckyRouter::PathPart.new("users")]
+    users_fragment = fragment.static_parts["users"]
     id_fragment = users_fragment.dynamic_part.not_nil!
-    id_fragment.static_parts[LuckyRouter::PathPart.new("edit")].should_not be_nil
-    id_fragment.static_parts[LuckyRouter::PathPart.new("new")].should_not be_nil
+    id_fragment.static_parts["edit"].should_not be_nil
+    id_fragment.static_parts["new"].should_not be_nil
   end
 end
 

--- a/spec/fragment_spec.cr
+++ b/spec/fragment_spec.cr
@@ -4,25 +4,29 @@ describe LuckyRouter::Fragment do
   it "adds parts successfully" do
     fragment = build_fragment
 
-    fragment.process_parts(["users", ":id"], "get", :show)
+    fragment.process_parts(build_path_parts("users", ":id"), "get", :show)
 
-    users_fragment = fragment.static_parts["users"]
+    users_fragment = fragment.static_parts[LuckyRouter::PathPart.new("users")]
     users_fragment.dynamic_part.should_not be_nil
   end
 
   it "static parts after dynamic parts do not overwrite each other" do
     fragment = build_fragment
 
-    fragment.process_parts(["users", ":id", "edit"], "get", :edit)
-    fragment.process_parts(["users", ":id", "new"], "get", :new)
+    fragment.process_parts(build_path_parts("users", ":id", "edit"), "get", :edit)
+    fragment.process_parts(build_path_parts("users", ":id", "new"), "get", :new)
 
-    users_fragment = fragment.static_parts["users"]
+    users_fragment = fragment.static_parts[LuckyRouter::PathPart.new("users")]
     id_fragment = users_fragment.dynamic_part.not_nil!
-    id_fragment.static_parts["edit"].should_not be_nil
-    id_fragment.static_parts["new"].should_not be_nil
+    id_fragment.static_parts[LuckyRouter::PathPart.new("edit")].should_not be_nil
+    id_fragment.static_parts[LuckyRouter::PathPart.new("new")].should_not be_nil
   end
 end
 
+private def build_path_parts(*path_parts) : Array(LuckyRouter::PathPart)
+  path_parts.map { |part| LuckyRouter::PathPart.new(part) }.to_a
+end
+
 private def build_fragment
-  LuckyRouter::Fragment(Symbol).new(name: "")
+  LuckyRouter::Fragment(Symbol).new(path_part: LuckyRouter::PathPart.new(""))
 end

--- a/spec/path_part_spec.cr
+++ b/spec/path_part_spec.cr
@@ -1,0 +1,100 @@
+require "./spec_helper"
+
+describe LuckyRouter::PathPart do
+  describe ".split_path" do
+    it "returns an array of path parts" do
+      path_parts = LuckyRouter::PathPart.split_path("/users/:id")
+
+      path_parts.size.should eq 3
+      path_parts[0].part.should eq ""
+      path_parts[1].part.should eq "users"
+      path_parts[2].part.should eq ":id"
+    end
+
+    it "ignores trailing slashes" do
+      path_parts = LuckyRouter::PathPart.split_path("/users/")
+
+      path_parts.size.should eq 2
+      path_parts[0].part.should eq ""
+      path_parts[1].part.should eq "users"
+    end
+  end
+
+  describe "#path_variable?" do
+    it "is true if it starts with colon" do
+      path_part = LuckyRouter::PathPart.new(":id")
+
+      path_part.path_variable?.should be_truthy
+    end
+
+    it "is false if it does not start with a colon" do
+      path_part = LuckyRouter::PathPart.new("users")
+
+      path_part.path_variable?.should be_falsey
+    end
+
+    it "is true if it is an optional path variable" do
+      path_part = LuckyRouter::PathPart.new("?:id")
+
+      path_part.path_variable?.should be_truthy
+    end
+  end
+
+  describe "#optional?" do
+    it "is true if it starts with a question mark" do
+      path_part = LuckyRouter::PathPart.new("?users")
+
+      path_part.optional?.should be_truthy
+    end
+
+    it "is false if it does not start with question mark" do
+      path_part = LuckyRouter::PathPart.new("users")
+
+      path_part.optional?.should be_falsey
+    end
+  end
+
+  describe "#name" do
+    it "returns part if part is not path variable" do
+      path_part = LuckyRouter::PathPart.new("users")
+
+      path_part.name.should eq "users"
+    end
+
+    it "returns path variable name if path variable" do
+      path_part = LuckyRouter::PathPart.new(":id")
+
+      path_part.name.should eq "id"
+    end
+
+    it "handles optional path parts" do
+      path_part = LuckyRouter::PathPart.new("?users")
+
+      path_part.name.should eq "users"
+    end
+
+    it "handles optional path variables" do
+      path_part = LuckyRouter::PathPart.new("?:id")
+
+      path_part.name.should eq "id"
+    end
+  end
+
+  describe "equality" do
+    it "is equal to another path part if their part is the same" do
+      part_a = LuckyRouter::PathPart.new("users")
+      part_b = LuckyRouter::PathPart.new("users")
+
+      part_a.should eq part_b
+      part_a.hash.should eq part_b.hash
+    end
+
+    it "is not equal to another path par if their part is different" do
+      part_a = LuckyRouter::PathPart.new("users")
+      part_b = LuckyRouter::PathPart.new(":users")
+
+      part_a.should_not eq part_b
+      part_a.hash.should_not eq part_b.hash
+    end
+  end
+end

--- a/src/lucky_router/fragment.cr
+++ b/src/lucky_router/fragment.cr
@@ -21,7 +21,7 @@
 # fragment.static_parts
 #
 # # Would return:
-# {PathPart("users") => Fragment, PathPart("posts") => Fragment}
+# {"users" => Fragment, "posts" => Fragment}
 #
 # # The Fragment in the 'users' key would have:
 #
@@ -30,7 +30,7 @@
 #
 # # Static parts
 # fragment.static_parts
-# {PathPart("foo") => Fragment}
+# {"foo" => Fragment}
 # ```
 #
 # ## Gotcha
@@ -39,7 +39,7 @@
 # dynamic parts
 class LuckyRouter::Fragment(T)
   property dynamic_part : Fragment(T)?
-  getter static_parts = Hash(PathPart, Fragment(T)).new
+  getter static_parts = Hash(String, Fragment(T)).new
   # Every path can have multiple request methods
   # and since each fragment represents a request path
   # the final step to finding the payload is to search for a matching request method
@@ -51,7 +51,7 @@ class LuckyRouter::Fragment(T)
 
   # This looks for a matching fragment for the given parts
   # and returns NoMatch if one is not found
-  def find(parts : Array(PathPart), method : String) : Match(T) | NoMatch
+  def find(parts : Array(String), method : String) : Match(T) | NoMatch
     # params are a key value pair of a path variable name matched to its value
     # so a path like /users/:id will have a path variable name of id and
     # a matching url of /users/456 will have a value of 456
@@ -61,7 +61,7 @@ class LuckyRouter::Fragment(T)
       break if match.nil?
 
       if match.dynamic?
-        params[match.path_part.name] = part.name
+        params[match.path_part.name] = part
       end
 
       match
@@ -76,11 +76,11 @@ class LuckyRouter::Fragment(T)
     leaf_fragment.method_to_payload[method] = payload
   end
 
-  def add_part(part : PathPart) : Fragment(T)
-    if part.path_variable?
-      self.dynamic_part ||= Fragment(T).new(path_part: part)
+  def add_part(path_part : PathPart) : Fragment(T)
+    if path_part.path_variable?
+      self.dynamic_part ||= Fragment(T).new(path_part: path_part)
     else
-      static_parts[part] ||= Fragment(T).new(path_part: part)
+      static_parts[path_part.part] ||= Fragment(T).new(path_part: path_part)
     end
   end
 

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -41,7 +41,8 @@ class LuckyRouter::Matcher(T)
   end
 
   def match(method : String, path_to_match : String) : Match(T)?
-    parts = PathPart.split_path(path_to_match)
+    parts = path_to_match.split('/')
+    parts.pop if parts.last.blank?
     match = root.find(parts, method)
 
     if match.is_a?(Match)

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -16,32 +16,23 @@
 # router.match("get", "/users").payload # :index
 # ```
 class LuckyRouter::Matcher(T)
-  # aliases to help clarify what the @routes has is made of
-  alias RoutePartsSize = Int32
-  alias HttpMethod = String
   # starting point from which all fragments are located
-  getter root = Fragment(T).new(name: "")
+  getter root = Fragment(T).new(path_part: PathPart.new(""))
 
   def add(method : String, path : String, payload : T)
-    all_path_parts = path.split("/")
-    optional_parts = [] of String
-    all_path_parts.each do |part|
-      if part.starts_with?("?")
-        optional_parts << part.gsub("?", "")
-      end
-    end
+    all_path_parts = PathPart.split_path(path)
+    optional_parts = all_path_parts.select(&.optional?)
 
-    path_without_optional_params = all_path_parts.reject(&.starts_with?("?")).join("/")
+    path_without_optional_params = all_path_parts.reject(&.optional?)
 
     process_and_add_path(method, path_without_optional_params, payload)
     optional_parts.each do |optional_part|
-      path_without_optional_params += "/#{optional_part}"
+      path_without_optional_params << optional_part
       process_and_add_path(method, path_without_optional_params, payload)
     end
   end
 
-  private def process_and_add_path(method : String, path : String, payload : T)
-    parts = extract_parts(path)
+  private def process_and_add_path(method : String, parts : Array(PathPart), payload : T)
     if method.downcase == "get"
       root.process_parts(parts, "head", payload)
     end
@@ -50,8 +41,8 @@ class LuckyRouter::Matcher(T)
   end
 
   def match(method : String, path_to_match : String) : Match(T)?
-    parts_to_match = extract_parts(path_to_match)
-    match = root.find(parts_to_match, method)
+    parts = PathPart.split_path(path_to_match)
+    match = root.find(parts, method)
 
     if match.is_a?(Match)
       match
@@ -60,11 +51,5 @@ class LuckyRouter::Matcher(T)
 
   def match!(method : String, path_to_match : String) : Match(T)
     match(method, path_to_match) || raise "No matching route found for: #{path_to_match}"
-  end
-
-  private def extract_parts(path)
-    parts = path.split("/")
-    parts.pop if parts.last.blank?
-    parts
   end
 end

--- a/src/lucky_router/path_part.cr
+++ b/src/lucky_router/path_part.cr
@@ -34,13 +34,19 @@ struct LuckyRouter::PathPart
   end
 
   getter part : String
-  getter name : String
-  getter? optional : Bool
-  getter? path_variable : Bool
 
   def initialize(@part)
-    @name = part.lchop('?').lchop(':')
-    @path_variable = part.starts_with?(':') || part.starts_with?("?:")
-    @optional = part.starts_with?('?')
+  end
+
+  def name
+    part.lchop('?').lchop(':')
+  end
+
+  def optional?
+    part.starts_with?('?')
+  end
+
+  def path_variable?
+    part.starts_with?(':') || part.starts_with?("?:")
   end
 end

--- a/src/lucky_router/path_part.cr
+++ b/src/lucky_router/path_part.cr
@@ -1,0 +1,46 @@
+# A PathPart represents a single section of a path
+#
+# It can be a static path
+#
+# ```crystal
+# path_part = PathPart.new("users")
+# path_part.path_variable? => false
+# path_part.optional? => false
+# path_part.name => "users"
+# ```
+#
+# It can be a path variable
+#
+# ```crystal
+# path_part = PathPart.new(":id")
+# path_part.path_variable? => true
+# path_part.optional? => false
+# path_part.name => "id"
+# ```
+#
+# It can be optional
+#
+# ```crystal
+# path_part = PathPart.new("?users")
+# path_part.path_variable? => false
+# path_part.optional? => true
+# path_part.name => "users"
+# ```
+struct LuckyRouter::PathPart
+  def self.split_path(path : String) : Array(PathPart)
+    parts = path.split('/')
+    parts.pop if parts.last.blank?
+    parts.map { |part| new(part) }
+  end
+
+  getter part : String
+  getter name : String
+  getter? optional : Bool
+  getter? path_variable : Bool
+
+  def initialize(@part)
+    @name = part.lchop('?').lchop(':')
+    @path_variable = part.starts_with?(':') || part.starts_with?("?:")
+    @optional = part.starts_with?('?')
+  end
+end


### PR DESCRIPTION
## Summary

This lifts up the path parts into a class. In two different places there was logic splitting the path into parts and they actually weren't the same. We were also doing a lot of string methods that had meaning beyond just search for a character in a string, like determining whether or not the part was a path variable. I believe this brings more simplicity to the code base and makes it a lot easier to add more functionality to in the future.

## Benchmark (with `--release`)

- Before: 156 ms
- After: 176 ms
- Difference: -20 ms
- Change: -13%