### PR TITLE
Handle multiple path variables at the same path level

### DIFF
--- a/spec/fragment_spec.cr
+++ b/spec/fragment_spec.cr
@@ -7,7 +7,7 @@ describe LuckyRouter::Fragment do
     fragment.process_parts(build_path_parts("users", ":id"), "get", :show)
 
     users_fragment = fragment.static_parts["users"]
-    users_fragment.dynamic_part.should_not be_nil
+    users_fragment.dynamic_parts.should_not be_empty
   end
 
   it "static parts after dynamic parts do not overwrite each other" do
@@ -17,7 +17,7 @@ describe LuckyRouter::Fragment do
     fragment.process_parts(build_path_parts("users", ":id", "new"), "get", :new)
 
     users_fragment = fragment.static_parts["users"]
-    id_fragment = users_fragment.dynamic_part.not_nil!
+    id_fragment = users_fragment.dynamic_parts.first
     id_fragment.static_parts["edit"].should_not be_nil
     id_fragment.static_parts["new"].should_not be_nil
   end

--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -134,6 +134,21 @@ describe LuckyRouter do
     router.match!("get", "/something").payload.should eq :category_index
   end
 
+  it "handles multiple path variables at the same path level" do
+    router = LuckyRouter::Matcher(Symbol).new
+
+    router.add("get", "/users/:user_id/inventory", :index)
+    router.add("get", "/users/:id", :show)
+
+    index_match = router.match!("get", "/users/123/inventory")
+    index_match.payload.should eq :index
+    index_match.params.should eq({"user_id" => "123"})
+
+    show_match = router.match!("get", "/users/123")
+    show_match.payload.should eq :show
+    show_match.params.should eq({"id" => "123"})
+  end
+
   describe "route with trailing slash" do
     router = LuckyRouter::Matcher(Symbol).new
     router.add("get", "/users/:id", :show)


### PR DESCRIPTION
Fixes #1 (It called for raising an error, but it is easy enough to just handle it as expected)

## Summary

This adds support for multiple path variables for a single section of a path. So, the router will now handle `/users/:id` and `/users/:user_id/settings` as expected. Before, it would only keep the first one that was added to the router and all others would be dropped. Now we store them all in an internal list.

## Benchmark (with `--release`)

- Before: 202 ms
- After: 283 ms
- Difference: -81 ms
- Change: -40% (I always forget how to do the math so this might be wrong)