### PR TITLE
Allow route globbing

### DIFF
--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -176,16 +176,16 @@ describe LuckyRouter do
     router.add("get", "/posts/something/?:optional_1/?:optional_2/*:glob_param", :post_index)
 
     router.match!("get", "/posts/something/1").params.should eq({
-      "optional_1" => "1"
+      "optional_1" => "1",
     })
     router.match!("get", "/posts/something/1/2").params.should eq({
       "optional_1" => "1",
-      "optional_2" => "2"
+      "optional_2" => "2",
     })
     router.match!("get", "/posts/something/1/2/3").params.should eq({
       "optional_1" => "1",
       "optional_2" => "2",
-      "glob_param" => "3"
+      "glob_param" => "3",
     })
   end
 

--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -187,6 +187,11 @@ describe LuckyRouter do
       "optional_2" => "2",
       "glob_param" => "3",
     })
+    router.match!("get", "/posts/something/1/2/3/4").params.should eq({
+      "optional_1" => "1",
+      "optional_2" => "2",
+      "glob_param" => "3/4",
+    })
   end
 
   describe "route with trailing slash" do

--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -156,6 +156,39 @@ describe LuckyRouter do
     end
   end
 
+  it "allows route globbing" do
+    router = LuckyRouter::Matcher(Symbol).new
+    router.add("get", "/posts/something/*", :post_index)
+
+    router.match!("get", "/posts/something").params.should eq({} of String => String)
+
+    router.match!("get", "/posts/something/1").params.should eq({
+      "glob" => "1",
+    })
+
+    router.match!("get", "/posts/something/1/something/longer").params.should eq({
+      "glob" => "1/something/longer",
+    })
+  end
+
+  it "allows route globbing and optional parts" do
+    router = LuckyRouter::Matcher(Symbol).new
+    router.add("get", "/posts/something/?:optional_1/?:optional_2/*:glob_param", :post_index)
+
+    router.match!("get", "/posts/something/1").params.should eq({
+      "optional_1" => "1"
+    })
+    router.match!("get", "/posts/something/1/2").params.should eq({
+      "optional_1" => "1",
+      "optional_2" => "2"
+    })
+    router.match!("get", "/posts/something/1/2/3").params.should eq({
+      "optional_1" => "1",
+      "optional_2" => "2",
+      "glob_param" => "3"
+    })
+  end
+
   describe "route with trailing slash" do
     router = LuckyRouter::Matcher(Symbol).new
     router.add("get", "/users/:id", :show)

--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -149,6 +149,13 @@ describe LuckyRouter do
     show_match.params.should eq({"id" => "123"})
   end
 
+  it "requires globs to be on the end of the path" do
+    router = LuckyRouter::Matcher(Symbol).new
+    expect_raises LuckyRouter::InvalidPathError do
+      router.add("get", "/posts/*/invalid_path", :invalid_path)
+    end
+  end
+
   describe "route with trailing slash" do
     router = LuckyRouter::Matcher(Symbol).new
     router.add("get", "/users/:id", :show)

--- a/spec/path_part_spec.cr
+++ b/spec/path_part_spec.cr
@@ -38,6 +38,12 @@ describe LuckyRouter::PathPart do
 
       path_part.path_variable?.should be_truthy
     end
+
+    it "is true if it is an glob path variable" do
+      path_part = LuckyRouter::PathPart.new("*:id")
+
+      path_part.path_variable?.should be_truthy
+    end
   end
 
   describe "#optional?" do
@@ -51,6 +57,20 @@ describe LuckyRouter::PathPart do
       path_part = LuckyRouter::PathPart.new("users")
 
       path_part.optional?.should be_falsey
+    end
+  end
+
+  describe "#glob?" do
+    it "is true if starts with asterisk" do
+      path_part = LuckyRouter::PathPart.new("*")
+
+      path_part.glob?.should be_truthy
+    end
+
+    it "is false if does not start with asterisk" do
+      path_part = LuckyRouter::PathPart.new("users")
+
+      path_part.glob?.should be_falsey
     end
   end
 
@@ -78,6 +98,12 @@ describe LuckyRouter::PathPart do
 
       path_part.name.should eq "id"
     end
+
+    it "handles glob path variables" do
+      path_part = LuckyRouter::PathPart.new("*:id")
+
+      path_part.name.should eq "id"
+    end
   end
 
   describe "equality" do
@@ -89,7 +115,7 @@ describe LuckyRouter::PathPart do
       part_a.hash.should eq part_b.hash
     end
 
-    it "is not equal to another path par if their part is different" do
+    it "is not equal to another path part if their part is different" do
       part_a = LuckyRouter::PathPart.new("users")
       part_b = LuckyRouter::PathPart.new(":users")
 

--- a/spec/path_part_spec.cr
+++ b/spec/path_part_spec.cr
@@ -39,8 +39,14 @@ describe LuckyRouter::PathPart do
       path_part.path_variable?.should be_truthy
     end
 
-    it "is true if it is an glob path variable" do
+    it "is true if it is a glob path variable" do
       path_part = LuckyRouter::PathPart.new("*:id")
+
+      path_part.path_variable?.should be_truthy
+    end
+
+    it "is true if it is just a glob so that it will be assigned correctly" do
+      path_part = LuckyRouter::PathPart.new("*")
 
       path_part.path_variable?.should be_truthy
     end
@@ -103,6 +109,12 @@ describe LuckyRouter::PathPart do
       path_part = LuckyRouter::PathPart.new("*:id")
 
       path_part.name.should eq "id"
+    end
+
+    it "is glob if glob without path variable name" do
+      path_part = LuckyRouter::PathPart.new("*")
+
+      path_part.name.should eq "glob"
     end
   end
 

--- a/spec/path_part_spec.cr
+++ b/spec/path_part_spec.cr
@@ -135,4 +135,20 @@ describe LuckyRouter::PathPart do
       part_a.hash.should_not eq part_b.hash
     end
   end
+
+  describe "#validate!" do
+    it "does nothing if path part is valid" do
+      part = LuckyRouter::PathPart.new("users")
+
+      part.validate!
+    end
+
+    it "raises error if glob named incorrectly" do
+      part = LuckyRouter::PathPart.new("*users")
+
+      expect_raises(LuckyRouter::InvalidGlobError) do
+        part.validate!
+      end
+    end
+  end
 end

--- a/src/lucky_router/errors.cr
+++ b/src/lucky_router/errors.cr
@@ -4,4 +4,10 @@ module LuckyRouter
 
   class InvalidPathError < LuckyRouterError
   end
+
+  class InvalidGlobError < LuckyRouterError
+    def initialize(glob)
+      super "Tried to define a glob as `#{glob}`, but it is invalid. Globs must be defined like `*` or given a name like `*:name`."
+    end
+  end
 end

--- a/src/lucky_router/errors.cr
+++ b/src/lucky_router/errors.cr
@@ -1,0 +1,7 @@
+module LuckyRouter
+  abstract class LuckyRouterError < Exception
+  end
+
+  class InvalidPathError < LuckyRouterError
+  end
+end

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -23,12 +23,20 @@ class LuckyRouter::Matcher(T)
     all_path_parts = PathPart.split_path(path)
     validate!(path, all_path_parts)
     optional_parts = all_path_parts.select(&.optional?)
+    glob_part = nil
+    if last_part = all_path_parts.last?
+      glob_part = all_path_parts.pop if last_part.glob?
+    end
 
     path_without_optional_params = all_path_parts.reject(&.optional?)
 
     process_and_add_path(method, path_without_optional_params, payload)
     optional_parts.each do |optional_part|
       path_without_optional_params << optional_part
+      process_and_add_path(method, path_without_optional_params, payload)
+    end
+    if glob_part
+      path_without_optional_params << glob_part
       process_and_add_path(method, path_without_optional_params, payload)
     end
   end

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -21,6 +21,7 @@ class LuckyRouter::Matcher(T)
 
   def add(method : String, path : String, payload : T)
     all_path_parts = PathPart.split_path(path)
+    validate!(path, all_path_parts)
     optional_parts = all_path_parts.select(&.optional?)
 
     path_without_optional_params = all_path_parts.reject(&.optional?)
@@ -52,5 +53,14 @@ class LuckyRouter::Matcher(T)
 
   def match!(method : String, path_to_match : String) : Match(T)
     match(method, path_to_match) || raise "No matching route found for: #{path_to_match}"
+  end
+
+  private def validate!(path : String, parts : Array(PathPart))
+    last_index = parts.size - 1
+    parts.each_with_index do |part, idx|
+      if part.glob? && idx != last_index
+        raise InvalidPathError.new("`#{path}` must only contain a glob at the end")
+      end
+    end
   end
 end

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -69,6 +69,7 @@ class LuckyRouter::Matcher(T)
       if part.glob? && idx != last_index
         raise InvalidPathError.new("`#{path}` must only contain a glob at the end")
       end
+      part.validate!
     end
   end
 end

--- a/src/lucky_router/path_part.cr
+++ b/src/lucky_router/path_part.cr
@@ -55,7 +55,17 @@ struct LuckyRouter::PathPart
     part.starts_with?('*')
   end
 
+  def validate!
+    raise InvalidGlobError.new(part) if invalid_glob?
+  end
+
   private def unnamed_glob?(name)
     name.blank? && glob?
+  end
+
+  private def invalid_glob?
+    return false unless glob?
+
+    part.size != 1 && part != "*:#{name}"
   end
 end

--- a/src/lucky_router/path_part.cr
+++ b/src/lucky_router/path_part.cr
@@ -39,7 +39,8 @@ struct LuckyRouter::PathPart
   end
 
   def name
-    part.lchop('?').lchop('*').lchop(':')
+    name = part.lchop('?').lchop('*').lchop(':')
+    unnamed_glob?(name) ? "glob" : name
   end
 
   def optional?
@@ -47,10 +48,14 @@ struct LuckyRouter::PathPart
   end
 
   def path_variable?
-    part.starts_with?(':') || part.starts_with?("?:") || part.starts_with?("*:")
+    part.starts_with?(':') || part.starts_with?("?:") || glob?
   end
 
   def glob?
     part.starts_with?('*')
+  end
+
+  private def unnamed_glob?(name)
+    name.blank? && glob?
   end
 end

--- a/src/lucky_router/path_part.cr
+++ b/src/lucky_router/path_part.cr
@@ -39,7 +39,7 @@ struct LuckyRouter::PathPart
   end
 
   def name
-    part.lchop('?').lchop(':')
+    part.lchop('?').lchop('*').lchop(':')
   end
 
   def optional?
@@ -47,6 +47,10 @@ struct LuckyRouter::PathPart
   end
 
   def path_variable?
-    part.starts_with?(':') || part.starts_with?("?:")
+    part.starts_with?(':') || part.starts_with?("?:") || part.starts_with?("*:")
+  end
+
+  def glob?
+    part.starts_with?('*')
   end
 end


### PR DESCRIPTION
Fixes #3 

This will allow using a glob pattern for paths. 

### Unnamed Usage

```crystal
router = LuckyRouter::Matcher(Symbol).new
router.add("get", "/users/*", :catch_all_users)

match = router.match!("get", "/users/catch/all/path")
match.params # => { "glob" => "catch/all/path" }
```

### Named Usage

```crystal
router = LuckyRouter::Matcher(Symbol).new
router.add("get", "/users/*:with_name", :catch_all_users)

match = router.match!("get", "/users/catch/all/path")
match.params # => { "with_name" => "catch/all/path" }
```

It is **required** that a glob can only go on the end of the path. Adding a path like `/users/*/extra` will result in a `LuckyRouter::InvalidPathError`

## Benchmark (with `--release`)

- Before: 267 ms
- After: 282 ms
- Difference: -15 ms
- Change: -6%