### PR TITLE
Raise when adding a duplicate route

### DIFF
--- a/spec/path_normalizer_spec.cr
+++ b/spec/path_normalizer_spec.cr
@@ -25,5 +25,13 @@ describe LuckyRouter::PathNormalizer do
 
       result.should eq("/users/name")
     end
+
+    it "removes question mark and gives generic name to optional path variables" do
+      path_parts = LuckyRouter::PathPart.split_path("/users/?:name")
+
+      result = LuckyRouter::PathNormalizer.normalize(path_parts)
+
+      result.should eq("/users/:path_variable")
+    end
   end
 end

--- a/spec/path_normalizer_spec.cr
+++ b/spec/path_normalizer_spec.cr
@@ -1,0 +1,29 @@
+require "./spec_helper"
+
+describe LuckyRouter::PathNormalizer do
+  describe ".normalize" do
+    it "turns regular path parts into slash delimitted string" do
+      path_parts = LuckyRouter::PathPart.split_path("/api/v1/users")
+
+      result = LuckyRouter::PathNormalizer.normalize(path_parts)
+
+      result.should eq("/api/v1/users")
+    end
+
+    it "gives path variables a generic name" do
+      path_parts = LuckyRouter::PathPart.split_path("/users/:id")
+
+      result = LuckyRouter::PathNormalizer.normalize(path_parts)
+
+      result.should eq("/users/:path_variable")
+    end
+
+    it "removes question mark from optional path" do
+      path_parts = LuckyRouter::PathPart.split_path("/users/?name")
+
+      result = LuckyRouter::PathNormalizer.normalize(path_parts)
+
+      result.should eq("/users/name")
+    end
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,3 @@
 require "spec"
 require "../src/lucky_router"
+require "uuid"

--- a/src/lucky_router/errors.cr
+++ b/src/lucky_router/errors.cr
@@ -10,4 +10,10 @@ module LuckyRouter
       super "Tried to define a glob as `#{glob}`, but it is invalid. Globs must be defined like `*` or given a name like `*:name`."
     end
   end
+
+  class DuplicateRouteError < LuckyRouterError
+    def initialize(method, path)
+      super "Router already contains a route matching a #{method.upcase} request to `#{path}`."
+    end
+  end
 end

--- a/src/lucky_router/path_normalizer.cr
+++ b/src/lucky_router/path_normalizer.cr
@@ -1,0 +1,11 @@
+class LuckyRouter::PathNormalizer
+  DEFAULT_PATH_VARIABLE_NAME = ":path_variable"
+
+  def self.normalize(path_parts : Array(PathPart)) : String
+    path_parts.map { |path_part| normalize(path_part) }.join('/')
+  end
+
+  private def self.normalize(path_part : PathPart) : String
+    path_part.path_variable? ? DEFAULT_PATH_VARIABLE_NAME : path_part.name
+  end
+end


### PR DESCRIPTION
Fixes #41 

LuckyRouter did not throw an error when adding duplicate routes. This caused confusion for people when they fell into this problem because there was no indication of what was going wrong. Now it will raise a runtime error that, in Lucky, means the app will fail to start.

A route is a combination of the request method and the path. Adding `GET /users/:id` and `GET /users/:user_id` is a duplicate while `GET /users/:id` and `POST /users/:user_id` is not.

The idea is that we keep a running list of normalized routes and throw an error if we get another one. By "normalized" I mean that we make an updated representation of the path with things that don't matter to this process (like globs, optionals, and unique path variable names) taken out. We concatenate that with the request method and push it onto a Set.

The normalization process will take a `GET /users/:id` and turn it into `get/users/:path_variable` so that if another request comes in with a different path variable name, we can still match it.