### PR TITLE
Provide more info in the duplicate route error

### DIFF
--- a/src/lucky_router/errors.cr
+++ b/src/lucky_router/errors.cr
@@ -12,8 +12,16 @@ module LuckyRouter
   end
 
   class DuplicateRouteError < LuckyRouterError
-    def initialize(method, path)
-      super "Router already contains a route matching a #{method.upcase} request to `#{path}`."
+    def initialize(method, new_path, duplicated_path)
+      super <<-ERROR
+      A route was attempted to be added that would overlap with an existing route.
+
+        Route to be added: #{method.upcase} #{new_path}
+        Existing route:    #{method.upcase} #{duplicated_path}
+
+      One of the routes should be updated to avoid the overlap.
+
+      ERROR
     end
   end
 end

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -18,7 +18,7 @@
 class LuckyRouter::Matcher(T)
   # starting point from which all fragments are located
   getter root = Fragment(T).new(path_part: PathPart.new(""))
-  getter normalized_paths = Set(String).new
+  getter normalized_paths = Hash(String, String).new
 
   def add(method : String, path : String, payload : T)
     all_path_parts = PathPart.split_path(path)
@@ -54,8 +54,8 @@ class LuckyRouter::Matcher(T)
 
   private def duplicate_check(method : String, parts : Array(PathPart), path : String)
     normalized_path = method.downcase + PathNormalizer.normalize(parts)
-    raise DuplicateRouteError.new(method, path) if normalized_paths.includes?(normalized_path)
-    normalized_paths << normalized_path
+    raise DuplicateRouteError.new(method, path) if normalized_paths.has_key?(normalized_path)
+    normalized_paths[normalized_path] = path
   end
 
   def match(method : String, path_to_match : String) : Match(T)?

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -54,7 +54,13 @@ class LuckyRouter::Matcher(T)
 
   private def duplicate_check(method : String, parts : Array(PathPart), path : String)
     normalized_path = method.downcase + PathNormalizer.normalize(parts)
-    raise DuplicateRouteError.new(method, path) if normalized_paths.has_key?(normalized_path)
+    if duplicated_path = normalized_paths[normalized_path]?
+      raise DuplicateRouteError.new(
+        method,
+        new_path: path,
+        duplicated_path: duplicated_path
+      )
+    end
     normalized_paths[normalized_path] = path
   end
 


### PR DESCRIPTION
Fixes https://github.com/luckyframework/lucky_router/issues/44

This error lists the incoming route that caused the error and the existing route that it would have duplicated/overlapped.

Duplicate vs overlap is causing me some confusion. It's not necessarily that they are the exact same routes. It's that some requests could be handled by either path. That's why I leaned toward using "overlap" in the error message.