### PR TITLE
URI decode path parts

### DIFF
--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -276,4 +276,13 @@ describe LuckyRouter do
       end
     end
   end
+
+  it "URI decodes path parts" do
+    router = LuckyRouter::Matcher(Symbol).new
+    router.add("get", "/users/:email/tasks", :show)
+
+    router.match!("get", "/users/foo%40example.com/tasks").params.should eq({
+      "email" => "foo@example.com",
+    })
+  end
 end

--- a/spec/path_part_spec.cr
+++ b/spec/path_part_spec.cr
@@ -18,6 +18,15 @@ describe LuckyRouter::PathPart do
       path_parts[0].part.should eq ""
       path_parts[1].part.should eq "users"
     end
+
+    it "decodes path parts" do
+      path_parts = LuckyRouter::PathPart.split_path("/users/foo%40example.com")
+
+      path_parts.size.should eq 3
+      path_parts[0].part.should eq ""
+      path_parts[1].part.should eq "users"
+      path_parts[2].part.should eq "foo@example.com"
+    end
   end
 
   describe "#path_variable?" do

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -1,5 +1,3 @@
-require "uri"
-
 # Add routes and match routes
 #
 # 'T' is the type of the 'payload'. The 'payload' is what will be returned
@@ -67,9 +65,7 @@ class LuckyRouter::Matcher(T)
   end
 
   def match(method : String, path_to_match : String) : Match(T)?
-    parts = path_to_match.split('/')
-    parts.pop if parts.last.blank?
-    parts.map! &->URI.decode(String)
+    parts = LuckerRouter::PathReader.new(path_to_match).to_a
     match = root.find(parts, method)
 
     if match.is_a?(Match)

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -1,3 +1,5 @@
+require "uri"
+
 # Add routes and match routes
 #
 # 'T' is the type of the 'payload'. The 'payload' is what will be returned
@@ -67,6 +69,7 @@ class LuckyRouter::Matcher(T)
   def match(method : String, path_to_match : String) : Match(T)?
     parts = path_to_match.split('/')
     parts.pop if parts.last.blank?
+    parts.map! &->URI.decode(String)
     match = root.find(parts, method)
 
     if match.is_a?(Match)

--- a/src/lucky_router/path_part.cr
+++ b/src/lucky_router/path_part.cr
@@ -1,5 +1,3 @@
-require "uri"
-
 # A PathPart represents a single section of a path
 #
 # It can be a static path
@@ -30,15 +28,13 @@ require "uri"
 # ```
 struct LuckyRouter::PathPart
   def self.split_path(path : String) : Array(PathPart)
-    parts = path.split('/')
-    parts.pop if parts.last.blank?
-    parts.map { |part| new(part) }
+    parts = LuckerRouter::PathReader.new(path)
+    parts.map { |part| new(part) }.to_a
   end
 
   getter part : String
 
-  def initialize(part)
-    @part = URI.decode(part)
+  def initialize(@part)
   end
 
   def name

--- a/src/lucky_router/path_part.cr
+++ b/src/lucky_router/path_part.cr
@@ -1,3 +1,5 @@
+require "uri"
+
 # A PathPart represents a single section of a path
 #
 # It can be a static path
@@ -35,7 +37,8 @@ struct LuckyRouter::PathPart
 
   getter part : String
 
-  def initialize(@part)
+  def initialize(part)
+    @part = URI.decode(part)
   end
 
   def name

--- a/src/lucky_router/path_reader.cr
+++ b/src/lucky_router/path_reader.cr
@@ -1,0 +1,59 @@
+require "char/reader"
+require "uri"
+
+# A PathReader parses a URI path into segments.
+#
+# It can be used to read a String representing a full path into the individual
+# segments it contains.
+#
+# ```
+# path = "/foo/bar/baz"
+# PathReader.new(path).to_a => ["", "foo", "bar", "baz"]
+# ```
+#
+# Percent-encoded characters are automatically decoded following segmentation
+#
+# ```
+# path = "/user/foo%40example.com/details"
+# PathReader.new(path).to_a => ["", "user", "foo@example.com", "details"]
+# ```
+class LuckerRouter::PathReader
+  include Enumerable(String)
+
+  def initialize(@path : String)
+  end
+
+  def each
+    each_segment do |offset, length, decode|
+      segment = String.new(@path.to_unsafe + offset, length)
+      if decode
+        yield URI.decode(segment)
+      else
+        yield segment
+      end
+    end
+  end
+
+  private def each_segment
+    decode = false
+    offset = 0
+
+    reader = Char::Reader.new(@path)
+    reader.each do |char|
+      case char
+      when '/'
+        length = reader.pos - offset
+        yield offset, length, decode
+        decode = false
+        offset = reader.pos + 1
+      when '%'
+        decode = true
+        reader.pos += 2
+      end
+    end
+
+    length = @path.bytesize - offset
+    return if length.zero?
+    yield offset, length, decode
+  end
+end


### PR DESCRIPTION
This PR introduces percent-decoding for information contained within path parts.

This ensures that all paths are normalised as per https://datatracker.ietf.org/doc/html/rfc3986#section-7.3 at the first valid opportunity.

Driving reason for this is to prevent the need for explicit decoding within [Spider Gazelle's action-controller](https://github.com/spider-gazelle/action-controller/blob/a4133cf27ddb3a1379ccf756b8566e72a7768d93/src/action-controller/router/route_handler.cr#L18) (which uses this) and could be placed there. This just appears to be the neat point to solve this more generally. If you feel that's a better spot, please do feel free to close this.