### PR TITLE
Release 0.5.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: lucky_router
-version: 0.4.2
+version: 0.5.0
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>

--- a/src/lucky_router/version.cr
+++ b/src/lucky_router/version.cr
@@ -1,3 +1,4 @@
 module LuckyRouter
-  VERSION = "0.4.2"
+  # The current LuckyRouter version is defined in `shard.yml`
+  VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
 end


### PR DESCRIPTION
This release bumps the minor version since it drops support for Crystal < 1.0.0. It also contains the updates to the URI decoding path parts.