### PR TITLE
More optimizations

### DIFF
--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -194,6 +194,15 @@ describe LuckyRouter do
     })
   end
 
+  it "matches a route with more than 16 segments" do
+    router = LuckyRouter::Matcher(Symbol).new
+    router.add("get", "/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/:z", :match)
+
+    match = router.match!("get", "/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z")
+    match.payload.should eq(:match)
+    match.params["z"].should eq("z")
+  end
+
   describe "route with trailing slash" do
     context "is defined with a trailing slash" do
       it "should treat it as a index route when called without a trailing slash" do

--- a/src/lucky_router/fragment.cr
+++ b/src/lucky_router/fragment.cr
@@ -128,9 +128,9 @@ class LuckyRouter::Fragment(T)
     if match = glob.match_for_method(method)
       match.params[glob.path_part.name] = String.build do |io|
         io << path_part
-        path_parts.each do |path_part|
+        path_parts.each do |next_path_part|
           io << '/'
-          io << path_part
+          io << next_path_part
         end
       end
       match

--- a/src/lucky_router/fragment.cr
+++ b/src/lucky_router/fragment.cr
@@ -132,9 +132,9 @@ class LuckyRouter::Fragment(T)
     if match = glob.match_for_method(method)
       match.params[glob.path_part.name] = String.build do |io|
         io << path_part
-        index.upto(path_parts.size - 1) do |index|
+        index.upto(path_parts.size - 1) do |sub_index|
           io << '/'
-          io << path_parts[index]
+          io << path_parts[sub_index]
         end
       end
       match

--- a/src/lucky_router/fragment.cr
+++ b/src/lucky_router/fragment.cr
@@ -53,7 +53,7 @@ class LuckyRouter::Fragment(T)
   # This looks for a matching fragment for the given parts
   # and returns NoMatch if one is not found
   def find(parts : Array(String), method : String) : Match(T) | NoMatch
-    find(Slice.new(parts.to_unsafe, parts.size), method)
+    find_match(parts, method) || NoMatch.new
   end
 
   # :ditto:
@@ -85,6 +85,10 @@ class LuckyRouter::Fragment(T)
     path_part.path_variable?
   end
 
+  def find_match(path_parts : Array(String), method : String) : Match(T)?
+    find_match(path_parts, 0, method)
+  end
+
   def find_match(path_parts : Slice(String), method : String) : Match(T)?
     find_match(path_parts, 0, method)
   end
@@ -94,43 +98,43 @@ class LuckyRouter::Fragment(T)
     payload ? Match(T).new(payload, Hash(String, String).new) : nil
   end
 
-  protected def find_match(path_parts : Slice(String), method : String) : Match(T)?
-    return match_for_method(method) if path_parts.empty?
+  protected def find_match(path_parts, index, method : String) : Match(T)?
+    return match_for_method(method) if index >= path_parts.size
 
-    path_part = path_parts[0]
-    path_parts = path_parts[1..]
+    path_part = path_parts[index]
+    index += 1
 
-    find_match_with_static_parts(path_part, path_parts, method) ||
-      find_match_with_dynamics(path_part, path_parts, method) ||
-      find_match_with_glob(path_part, path_parts, method)
+    find_match_with_static_parts(path_part, path_parts, index, method) ||
+      find_match_with_dynamics(path_part, path_parts, index, method) ||
+      find_match_with_glob(path_part, path_parts, index, method)
   end
 
-  private def find_match_with_static_parts(path_part, path_parts, method)
+  private def find_match_with_static_parts(path_part, path_parts, index, method)
     static_part = static_parts[path_part]?
     return unless static_part
 
-    static_part.find_match(path_parts, method)
+    static_part.find_match(path_parts, index, method)
   end
 
-  private def find_match_with_dynamics(path_part, path_parts, method)
+  private def find_match_with_dynamics(path_part, path_parts, index, method)
     dynamic_parts.each do |dynamic_part|
-      if match = dynamic_part.find_match(path_parts, method)
+      if match = dynamic_part.find_match(path_parts, index, method)
         match.params[dynamic_part.path_part.name] = path_part
         return match
       end
     end
   end
 
-  private def find_match_with_glob(path_part, path_parts, method)
+  private def find_match_with_glob(path_part, path_parts, index, method)
     glob = glob_part
     return unless glob
 
     if match = glob.match_for_method(method)
       match.params[glob.path_part.name] = String.build do |io|
         io << path_part
-        path_parts.each do |next_path_part|
+        index.upto(path_parts.size - 1) do |index|
           io << '/'
-          io << next_path_part
+          io << path_parts[index]
         end
       end
       match

--- a/src/lucky_router/match.cr
+++ b/src/lucky_router/match.cr
@@ -1,4 +1,4 @@
-class LuckyRouter::Match(T)
+struct LuckyRouter::Match(T)
   getter payload : T
   getter params : Hash(String, String)
 

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -67,7 +67,7 @@ class LuckyRouter::Matcher(T)
   def match(method : String, path_to_match : String) : Match(T)?
     # To avoid allocating an array for the segment parts, we use a static
     # array with up to 16 segments.
-    parts_static_array = uninitialized StaticArray(String, 16)
+    parts_static_array = StaticArray(String, 16).new("")
 
     # In the general case we still have to support more than 16 segments.
     # We'll fallback to using an Array for that case.

--- a/src/lucky_router/path_reader.cr
+++ b/src/lucky_router/path_reader.cr
@@ -35,20 +35,25 @@ struct LuckerRouter::PathReader
   end
 
   private def each_segment
-    decode = false
+    index = 0
     offset = 0
+    decode = false
+    slice = @path.to_slice
 
-    reader = Char::Reader.new(@path)
-    reader.each do |char|
-      case char
+    while index < slice.size
+      byte = slice[index]
+      case byte
       when '/'
-        length = reader.pos - offset
+        length = index - offset
         yield offset, length, decode
         decode = false
-        offset = reader.pos + 1
+        index += 1
+        offset = index
       when '%'
         decode = true
-        reader.pos += 2
+        index += 3
+      else
+        index += 1
       end
     end
 


### PR DESCRIPTION
Follow up to #54

The old benchmark time (check #54) was this:

```
router 489.51k (  2.04µs) (± 4.33%)  2.02kB/op  fastest
```

Now it's this:

```
router 758.39k (  1.32µs) (± 3.57%)  1.33kB/op  fastest
```

After this, it seems most of the time is spent creating the `params` Hash of each match, and creating strings for each segment. There might be a chance to use `Bytes` for each segment to avoid those allocations, but maybe it would be too much (the overall API would change a lot.) Then, maybe the `params` Hash of a match could be lazily instantiated, but it might not be worth it if frameworks using the router will always put stuff in the `params` Hash. So this is probably a good stopping point :-)