### PR TITLE
Improve no match performance using a struct

### DIFF
--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -20,6 +20,7 @@ elapsed_times = [] of Time::Span
       router.match!("put", "/users/1")
       router.match!("get", "/users/1/edit")
       router.match!("get", "/users/1/new")
+      router.match("get", "/no/match/found")
     end
   end
   elapsed_times << elapsed

--- a/src/lucky_router/no_match.cr
+++ b/src/lucky_router/no_match.cr
@@ -1,2 +1,2 @@
-class LuckyRouter::NoMatch
+struct LuckyRouter::NoMatch
 end


### PR DESCRIPTION
Previously in https://github.com/luckyframework/lucky_router/pull/55 the `Match` result was converted from a class to a struct however the `NoMatch` case was left as a class. I also added a case to the benchmark script for this case as previously it was only matches. 

**Before**

```
Average time: 121.66ms
```

**After**

```
Average time: 114.73ms
```
