### PR TITLE
Clean up Windows Support to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,13 @@ jobs:
   check_format:
     strategy:
       fail-fast: false
-      matrix:
-        crystal_version:
-          - latest
-        experimental:
-          - false
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: false
     steps:
-      - uses: actions/checkout@v2
-      - uses: crystal-lang/install-crystal@v1
-        with:
-          crystal: ${{matrix.crystal_version}}
+      - name: Download source
+        uses: actions/checkout@v3
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
       - name: Install shards
         run: shards install
       - name: Format
@@ -32,24 +27,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        crystal_version:
-          - 1.6.2
-          - latest
-        experimental:
-          - false
+        os: [ubuntu-latest, windows-latest]
+        crystal_version: [latest]
         include:
-          - os: windows-latest
-            crystal_version: latest
-            experimental: true
+          - os: ubuntu-latest
+            crystal_version: 1.6.2
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: ${{matrix.crystal_version}}
+          crystal: ${{ matrix.crystal_version }}
       - name: Install dependencies
-        run: shards install
+        run: shards install --skip-postinstall --skip-executables
       - name: Run tests
         run: crystal spec


### PR DESCRIPTION
Windows Support was already added it looks like a while ago, but this just standardizes it with other Lucky shards.