### PR TITLE
Adds ability to list routes for lucky routes command

### DIFF
--- a/spec/fragment_spec.cr
+++ b/spec/fragment_spec.cr
@@ -21,6 +21,22 @@ describe LuckyRouter::Fragment do
     id_fragment.static_parts["edit"].should_not be_nil
     id_fragment.static_parts["new"].should_not be_nil
   end
+
+  describe "#collect_routes" do
+    it "returns list of routes from fragment" do
+      fragment = build_fragment
+      fragment.process_parts(build_path_parts("users", ":id"), "get", :show)
+
+      result = fragment.collect_routes
+
+      result.size.should eq(1)
+      result[0].should eq({
+        [LuckyRouter::PathPart.new(""), LuckyRouter::PathPart.new("users"), LuckyRouter::PathPart.new(":id")],
+        "get",
+        :show,
+      })
+    end
+  end
 end
 
 private def build_path_parts(*path_parts) : Array(LuckyRouter::PathPart)

--- a/src/lucky_router/matcher.cr
+++ b/src/lucky_router/matcher.cr
@@ -42,6 +42,14 @@ class LuckyRouter::Matcher(T)
     end
   end
 
+  # Array of the path, method, and payload
+  def list_routes : Array(Tuple(String, String, T))
+    root.collect_routes.map do |(path_parts, method, payload)|
+      path = "/" + path_parts.reject(&.part.presence.nil?).map(&.part).join("/")
+      Tuple.new(path, method, payload)
+    end
+  end
+
   private def process_and_add_path(method : String, parts : Array(PathPart), payload : T, path : String)
     if method.downcase == "get"
       root.process_parts(parts, "head", payload)


### PR DESCRIPTION
Fixes #57 

Lucky stores its own routes array and it is only for the `lucky routes` CLI command. By adding this functionality here, we remove the need for that. The basic logic of this code is that a fragment returns a list of any methods to payload that it has along with its path. Beyond that, it cycles through any sub-fragments it might have and does the same for those and prepends its own path to any results received from it. That ultimately bubbles up to a single list of routes. Only thing we do beyond that is to convert the list of PathPart's into a string. We filter out any of the blank path parts that are at the start and join with "/" and make sure to prepend one as well. It gets a little funky when query params are passed in, but Lucky doesn't do that at all so it shouldn't be a problem. The problem there is that it makes a ton of routes. With query param, without, not including if there's more than one.

Lucky router with duplicate routes array: https://github.com/luckyframework/lucky/blob/main/src/lucky/router.cr
CLI command: https://github.com/luckyframework/lucky/blob/main/tasks/routes.cr